### PR TITLE
Raise alarm when retrieved dataset differ from expected

### DIFF
--- a/expected-datasets-api.json
+++ b/expected-datasets-api.json
@@ -498,6 +498,11 @@
             "id": "y3gg-ygkc",
             "name": "Tampa CV Pilot Traveler Information Message (TIM) (Restricted Access)",
             "url": "https://datahub.transportation.gov/Automobiles/Tampa-CV-Pilot-Traveler-Information-Message-TIM-Re/y3gg-ygkc"
+        },
+        {
+            "id": "dsgr-arn8",
+            "name": "Feasibility Study and Assessment of Communications Approaches for Real-Time Traffic Signal Applications Study Data",
+            "url": "https://datahub.transportation.gov/Research-and-Statistics/Feasibility-Study-and-Assessment-of-Communications/dsgr-arn8"
         }
     ]
 }

--- a/package.sh
+++ b/package.sh
@@ -15,7 +15,7 @@ if [ -f "$PACKAGE_FILENAME" ]; then
 fi
 
 mkdir $PACKAGE_FOLDER
-pip install -r requirements.txt --upgrade --target ./_package
+pip install -r requirements_lambda.txt --upgrade --target ./_package
 cp *.py ./$PACKAGE_FOLDER
 cp *.json ./$PACKAGE_FOLDER
 cd $PACKAGE_FOLDER

--- a/requirements_lambda.txt
+++ b/requirements_lambda.txt
@@ -1,0 +1,3 @@
+certifi==2019.6.16
+chardet==3.0.4
+requests==2.22.0


### PR DESCRIPTION
This PR does the following:
- Add feasibility dataset to expected dataset JSON
- Raise alarm when retrieved list of datasets differ from expected so that we can trigger cloudwatch alarms.
- Refactor DHDatasetVerification._compare_datasets
- Create lambda-specific requirements file to avoid bloating of lambda package

(will have separate PR for the features next time - thanks for your review!)